### PR TITLE
Use overridePreviewUrl before preview render

### DIFF
--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -58,8 +58,8 @@ const Tab = (props) => {
 
     let imageUrl = image.cdnUrl + '-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/'
 
-    if (settings.overridePreviewUrl) {
-      imageUrl = settings.overridePreviewUrl(imageUrl, image)
+    if (settings.previewUrlCallback) {
+      imageUrl = settings.previewUrlCallback(imageUrl, image)
     }
 
     _image = new Image({
@@ -235,8 +235,8 @@ const Tab = (props) => {
     const {image} = store.getState()
     let imageUrl = image.cdnUrl + '-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/'
 
-    if (settings.overridePreviewUrl) {
-      imageUrl = settings.overridePreviewUrl(imageUrl, image)
+    if (settings.previewUrlCallback) {
+      imageUrl = settings.previewUrlCallback(imageUrl, image)
     }
 
     _image.updateImageUrl(imageUrl)

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -56,8 +56,14 @@ const Tab = (props) => {
 
     _content = new Content()
 
+    let imageUrl = image.cdnUrl + '-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/'
+
+    if (settings.overridePreviewUrl) {
+      imageUrl = settings.overridePreviewUrl(imageUrl, image)
+    }
+
     _image = new Image({
-      imageUrl: image.cdnUrl + '-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/',
+      imageUrl: imageUrl,
       onUpdate: () => store.setImageLoad('start'),
       onLoad: () => store.setImageLoad('load'),
       onFail: () => store.setImageLoad('fail'),
@@ -227,7 +233,11 @@ const Tab = (props) => {
 
   const handleImageChange = () => {
     const {image} = store.getState()
-    const imageUrl = image.cdnUrl + '-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/'
+    let imageUrl = image.cdnUrl + '-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/'
+
+    if (settings.overridePreviewUrl) {
+      imageUrl = settings.overridePreviewUrl(imageUrl, image)
+    }
 
     _image.updateImageUrl(imageUrl)
   }


### PR DESCRIPTION
Update Effects Tab to work with secure CDN previews

https://github.com/uploadcare/uploadcare-widget/pull/454