### PR TITLE
Clear img src before update it

### DIFF
--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -40,6 +40,12 @@ const Image = (props) => {
   }
 
   const updateImageUrl = (imageUrl) => {
+    if ($img.src === imageUrl) {
+      // safari do not call onload event when url is the same
+      // so we manually clear it before update
+      $img.removeAttribute('src')
+    }
+
     $img.src = imageUrl
 
     onUpdate()


### PR DESCRIPTION
Safari do not fire `onload` event when Image src is updated with the same url. 
So we clear src property before assign a new one and Safari start working as expected.