### PR TITLE
fix auto-crop

### DIFF
--- a/src/tools/auto-crop.js
+++ b/src/tools/auto-crop.js
@@ -1,15 +1,15 @@
 const autoCrop = (store, settings, uc) => {
-  const {crop: cropSettings, multiple} = settings
+  const {crop, multiple} = settings
   const {image} = store.getState()
 
   // auto-crop only in single file mode
-  if (!cropSettings || !multiple) {
+  if (!crop || !multiple) {
     return
   }
 
   // if even one of crop option sets allow free crop,
   // we don't need to crop automatically
-  if (cropSettings.some(c => !c.preferedSize)) {
+  if (crop.some(c => !c.preferedSize)) {
     return
   }
 
@@ -24,7 +24,7 @@ const autoCrop = (store, settings, uc) => {
     true
   )
 
-  const crop = {
+  const cropEffect = {
     originalSize: [info.width, info.height],
     coords: {
       left: Math.round((info.width - size[0]) / 2),
@@ -34,7 +34,7 @@ const autoCrop = (store, settings, uc) => {
     },
   }
 
-  store.setAppliedEffect({crop})
+  store.setAppliedEffect({crop: cropEffect})
   store.rebuildImage()
 }
 

--- a/src/tools/auto-crop.js
+++ b/src/tools/auto-crop.js
@@ -2,8 +2,14 @@ const autoCrop = (store, settings, uc) => {
   const {crop: cropSettings, multiple} = settings
   const {image} = store.getState()
 
-  // auto-crop only in single mode with free crop disabled
-  if (multiple || cropSettings.some(c => !c.preferedSize)) {
+  // auto-crop only in single file mode
+  if (!cropSettings || !multiple) {
+    return
+  }
+
+  // if even one of crop option sets allow free crop,
+  // we don't need to crop automatically
+  if (cropSettings.some(c => !c.preferedSize)) {
     return
   }
 


### PR DESCRIPTION
This module was copied from original widget source, but I forgot to check `crop settings` for `false` value.

```
  if not @settings.crop or not @settings.multiple
        return

      for crop in @settings.crop
        # if even one of crop option sets allow free crop,
        # we don't need to crop automatically
        if not crop.preferedSize
          return
```