### PR TITLE
#includes -> #indexOf, for IE support

### DIFF
--- a/src/tools/configure-translations.js
+++ b/src/tools/configure-translations.js
@@ -9,7 +9,7 @@ import initialSettings from '../initial-settings'
 const isLocaleAvailable = locale => {
   const availableLocales = Object.keys(locales)
 
-  return availableLocales.includes(locale)
+  return availableLocales.indexOf(locale) > -1
 }
 
 /**


### PR DESCRIPTION
https://github.com/uploadcare/uploadcare-widget-tab-effects/blob/master/src/tools/configure-translations.js#L12

...isn't supported in IE, which stops the Uploadcare widget from completing an upload in IE when the effects tab is loaded. 

Changing `includes` to `indexOf` gets things working again in IE11 (I haven't tested earlier versions).